### PR TITLE
Forward raml2obj parse error

### DIFF
--- a/lib/raml2wiki.js
+++ b/lib/raml2wiki.js
@@ -69,9 +69,7 @@ raml2obj.parse(source).then(function (ramlObj) {
 
 	_render(ramlObj, config, onSuccess);
 
-	}
-
-)};
+}, onError)};
 
 
 function parse(source, template, onSuccess, onError) {


### PR DESCRIPTION
That forwards the parsing error so the user can know that his file is invalid.